### PR TITLE
Add LRCLIB as a provider for the lyrics plugin

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -312,7 +312,10 @@ class LRCLib(Backend):
             self._log.debug("LRCLib API request failed: {0}", exc)
             return None
 
-        return data.get("syncedLyrics") or data.get("plainLyrics")
+        if self.config["synced"]:
+            return data.get("syncedLyrics")
+
+        return data.get("plainLyrics")
 
 
 class MusiXmatch(Backend):
@@ -796,6 +799,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
                 "fallback": None,
                 "force": False,
                 "local": False,
+                "synced": False,
                 # Musixmatch is disabled by default as they are currently blocking
                 # requests with the beets user agent.
                 "sources": [s for s in self.SOURCES if s != "musixmatch"],

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -141,7 +141,8 @@ New features:
   but no thumbnail is provided by CAA. We now fallback to the raw image.
 * :doc:`/plugins/advancedrewrite`: Add an advanced version of the `rewrite`
   plugin which allows to replace fields based on a given library query.
-* :doc:`/plugins/lyrics`: Add LRCLIB as a new lyrics provider.
+* :doc:`/plugins/lyrics`: Add LRCLIB as a new lyrics provider and a new
+  `synced` option to prefer synced lyrics over plain lyrics.
 
 Bug fixes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -141,6 +141,7 @@ New features:
   but no thumbnail is provided by CAA. We now fallback to the raw image.
 * :doc:`/plugins/advancedrewrite`: Add an advanced version of the `rewrite`
   plugin which allows to replace fields based on a given library query.
+* :doc:`/plugins/lyrics`: Add LRCLIB as a new lyrics provider.
 
 Bug fixes:
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -64,6 +64,7 @@ configuration file. The available options are:
   is setup.
   The ``google``, ``genius``, and ``tekstowo`` sources will only be enabled if
   BeautifulSoup is installed.
+- **synced**: Prefer synced lyrics over plain lyrics if a source offers them. Currently `lrclib` is the only source that provides them. Default: `no`.
 
 Here's an example of ``config.yaml``::
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -2,11 +2,12 @@ Lyrics Plugin
 =============
 
 The ``lyrics`` plugin fetches and stores song lyrics from databases on the Web.
-Namely, the current version of the plugin uses `Genius.com`_, `Tekstowo.pl`_,
+Namely, the current version of the plugin uses `Genius.com`_, `Tekstowo.pl`_, `LRCLIB`_
 and, optionally, the Google custom search API.
 
 .. _Genius.com: https://genius.com/
 .. _Tekstowo.pl: https://www.tekstowo.pl/
+.. _LRCLIB: https://lrclib.net/
 
 
 Fetch Lyrics During Import
@@ -58,7 +59,7 @@ configuration file. The available options are:
   sources known to be scrapeable.
 - **sources**: List of sources to search for lyrics. An asterisk ``*`` expands
   to all available sources.
-  Default: ``google genius tekstowo``, i.e., all the available sources. The
+  Default: ``google genius tekstowo lrclib``, i.e., all the available sources. The
   ``google`` source will be automatically deactivated if no ``google_API_key``
   is setup.
   The ``google``, ``genius``, and ``tekstowo`` sources will only be enabled if

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -697,7 +697,10 @@ class LRCLibLyricsTest(unittest.TestCase):
         mock_get.return_value.status_code = 200
 
         lyrics = lrclib.fetch("la", "la", "la", 999)
+        self.assertEqual(lyrics, mock_response["plainLyrics"])
 
+        self.plugin.config["synced"] = True
+        lyrics = lrclib.fetch("la", "la", "la", 999)
         self.assertEqual(lyrics, mock_response["syncedLyrics"])
 
     @patch("beetsplug.lyrics.requests.get")


### PR DESCRIPTION
## Description

This PR adds support for [LRCLIB ](https://lrclib.net) as a lyrics provider.

I recently set up Navidrome on my home server and the web UI for that [only supports embedded, synced lyrics](https://github.com/navidrome/navidrome/issues/491#issuecomment-946782864). From what I can tell, the current lyric providers only return plain lyrics. I did a little research and found LRCLIB, which offers an [easy to use API](https://lrclib.net/docs) that includes both synced and plain lyrics.

Inspired by https://github.com/tranxuanthang/lrcget/issues/2#issuecomment-1471512530.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
